### PR TITLE
adds check for unintentional overrides, fixes #4

### DIFF
--- a/component.json
+++ b/component.json
@@ -12,11 +12,11 @@
     "ianstormtaylor/is": "*",
     "component/each": "*",
     "ianstormtaylor/sinon": "*",
+    "segmentio/analytics.js-integration": "*",
     "jkroso/equals": "*",
     "yields/fmt": "*"
   },
   "development": {
-    "segmentio/analytics.js-integration": "*",
     "component/assert": "*"
   },
   "main": "lib/index.js",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 
+var Integration = require('integration');
 var Assertion = require('./assertion');
 var types = require('./types');
 var assert = require('assert');
@@ -6,6 +7,27 @@ var equal = require('equals');
 var indexOf = require('indexof');
 var each = require('each');
 var is = require('is');
+
+/**
+ * Override-able methods
+ */
+
+var methods = [
+  'alias',
+  'group',
+  'identify',
+  'initialize',
+  'load',
+  'map',
+  'page',
+  'track'
+];
+
+/**
+ * Base integration class
+ */
+
+var Base = Integration('Base');
 
 /**
  * Expose `Tester`.
@@ -34,6 +56,20 @@ exports.types = types;
 function Tester (integration) {
   if (!(this instanceof Tester)) return new Tester(integration);
   this.integration = integration;
+  for (var property in integration) {
+    var override = integration[property];
+    var parent = Base.prototype[property];
+
+    if (indexOf(methods, property) > -1) continue; // public method
+    if (!parent) continue;
+
+    var msg = 'Don\'t override the "' + property
+      + '" method from the base integration';
+
+    assert(typeof override === typeof parent, msg);
+    if (typeof override !== 'function') continue;
+    assert(override === parent, msg);
+  }
 }
 
 
@@ -90,7 +126,7 @@ Tester.prototype.option = function (key, value) {
 
 /**
  * Assert that the integration has `mapping` of `name`.
- * 
+ *
  * @param {String} name
  * @return {Tester}
  */

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,18 @@ describe('integration-tester', function () {
       .readyOnLoad();
   });
 
+  it('should not allow overriding of private methods', function(){
+    var integration = new Integration();
+    integration.queue = function(){};
+    var error;
+    try {
+      tester(integration)
+    } catch (err) {
+      error = err;
+    }
+    assert(error);
+  });
+
   it('should expose facade\'s methods on .types', function(){
     assert(tester.types);
     assert(tester.types.identify);


### PR DESCRIPTION
So that we don't accidentally overwrite stuff like .queue, .invoke,
etc.

Sure I missed a few methods in the overrides that we should be
including so check my math here :)

@lancejpollard @yields 
