### PR TITLE
rename `with` to `args` so IE8 tests pass

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -1,17 +1,21 @@
 
-var has = ({}).hasOwnProperty;
+/**
+ * Module dependencies.
+ */
+
 var equals = require('equals');
 var assert = require('assert');
+var has = ({}).hasOwnProperty;
 var fmt = require('fmt');
 
 /**
- * Expose `Assertion`
+ * Expose `Assertion`.
  */
 
 module.exports = Assertion;
 
 /**
- * Initialize `Assertion`
+ * Initialize `Assertion`.
  *
  * @api private
  */
@@ -49,7 +53,7 @@ Assertion.prototype.called = function(spy){
  * @api public
  */
 
-Assertion.prototype['with'] = function(){
+Assertion.prototype.args = function(){
   var args = [].slice.call(arguments);
 
   assert(has.call(this, 'spy'), 'you must call .called(spy) prior to calling this method.');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,14 @@
 
+/**
+ * Module dependencies.
+ */
+
 var Integration = require('integration');
 var Assertion = require('./assertion');
+var indexOf = require('indexof');
 var types = require('./types');
 var assert = require('assert');
 var equal = require('equals');
-var indexOf = require('indexof');
 var each = require('each');
 var is = require('is');
 
@@ -54,7 +58,7 @@ exports.types = types;
  * @param {Integration} integration
  */
 
-function Tester (integration) {
+function Tester(integration) {
   if (!(this instanceof Tester)) return new Tester(integration);
   this.integration = integration;
   for (var property in integration) {
@@ -64,14 +68,14 @@ function Tester (integration) {
     if (indexOf(methods, property) > -1) continue; // public method
     if (!parent) continue;
 
-    var msg = 'Don\'t override the "' + property
+    var msg = 'Don\'t override the "' 
+      + property
       + '" method from the base integration';
 
     if (typeof override !== 'function') continue;
     assert(String(override) === String(parent), msg);
   }
 }
-
 
 /**
  * Assert that the integration's name is `string`.
@@ -80,7 +84,7 @@ function Tester (integration) {
  * @return {Tester}
  */
 
-Tester.prototype.name = function (string) {
+Tester.prototype.name = function(string){
   var name = this.integration.name;
   assert(
     string === name,
@@ -89,7 +93,6 @@ Tester.prototype.name = function (string) {
   return this;
 };
 
-
 /**
  * Assert that the integration has a global `key`.
  *
@@ -97,14 +100,13 @@ Tester.prototype.name = function (string) {
  * @return {Tester}
  */
 
-Tester.prototype.global = function (key) {
+Tester.prototype.global = function(key){
   assert(
     indexOf(this.integration.globals, key) !== -1,
     'Expected global "' + key + '" to be registered.'
   );
   return this;
 };
-
 
 /**
  * Assert that the integration has an `option` with a default `value`.
@@ -114,7 +116,7 @@ Tester.prototype.global = function (key) {
  * @return {Tester}
  */
 
-Tester.prototype.option = function (key, value) {
+Tester.prototype.option = function(key, value){
   var val = this.integration.defaults[key];
   var obj = is.object(val) || is.array(val);
   assert(
@@ -141,7 +143,7 @@ Tester.prototype.mapping = function(name){
  * @return {Tester}
  */
 
-Tester.prototype.assumesPageview = function () {
+Tester.prototype.assumesPageview = function(){
   assert(
     this.integration._assumesPageview,
     'Expected integration to assume a pageview.'
@@ -149,14 +151,13 @@ Tester.prototype.assumesPageview = function () {
   return this;
 };
 
-
 /**
  * Assert that the integration is ready on initialize.
  *
  * @return {Tester}
  */
 
-Tester.prototype.readyOnInitialize = function () {
+Tester.prototype.readyOnInitialize = function(){
   assert(
     this.integration._readyOnInitialize,
     'Expected integration to be ready on initialize.'
@@ -185,7 +186,7 @@ Tester.prototype.loads = function(fn){
  * @return {Tester}
  */
 
-Tester.prototype.readyOnLoad = function () {
+Tester.prototype.readyOnLoad = function(){
   assert(
     this.integration._readyOnLoad,
     'Expected integration to be ready on load.'

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 
-describe('integration-tester', function () {
+describe('integration-tester', function(){
 
   var createIntegration = require('integration');
   var tester = require('integration-tester');
@@ -252,10 +252,10 @@ describe('integration-tester', function () {
       })
     })
 
-    describe('.with()', function(){
+    describe('.args()', function(){
       it('should throw if theres no spy', function(){
         try {
-          assertion.with();
+          assertion.args();
           assert(false);
         } catch (e) {
           assert(~e.message.indexOf('.called(spy)'));
@@ -269,7 +269,7 @@ describe('integration-tester', function () {
         try {
           assertion
           .called(proxy)
-          .with('baz');
+          .args('baz');
           assert(false);
         } catch (e) {
           assert(~e.message.indexOf('"baz"'));
@@ -280,7 +280,7 @@ describe('integration-tester', function () {
       it('should not throw and delete the spy if assertion is correct', function(){
         var proxy = sinon.spy(function(){});
         proxy('baz');
-        var ret = assertion.called(proxy).with('baz');
+        var ret = assertion.called(proxy).args('baz');
         assert(!assertion.hasOwnProperty('spy'));
         assert(ret == assertion);
       })


### PR DESCRIPTION
@calvinfo going to make these changes to analytics.js-integrations too
