### PR TITLE
cleanup some methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ function plugin(analytics) {
    * @return {Analytics}
    */
 
-  analytics.notCalled =
   analytics.didNotCall = function(spy){
     assert(
       ~indexOf(this.spies, spy),
@@ -209,7 +208,6 @@ function plugin(analytics) {
    * @return {Tester}
    */
 
-  analytics.notReturned =
   analytics.didNotReturn = function(spy, value){
     assert(
       ~indexOf(this.spies, spy),
@@ -236,13 +234,15 @@ function plugin(analytics) {
   };
 
   /**
-   * Validate `int` against `test`.
+   * Compare `int` against `test`.
+   *
+   * To double-check that they have the right defaults, globals, and config.
    *
    * @param {Function} a actual integration constructor
    * @param {Function} b test integration constructor
    */
 
-  analytics.validate = function(a, b){
+  analytics.compare = function(a, b){
     a = new a;
     b = new b;
     // name

--- a/test/index.js
+++ b/test/index.js
@@ -23,15 +23,13 @@ describe('integration-tester', function(){
     analytics.add(integration);
   });
 
-  it('should work', function(){
-    var Test = createIntegration('Name')
+  it('should compare two integrations', function(){
+    analytics.compare(Integration, createIntegration('Name')
       .global('global')
       .option('option', 'value')
       .option('object', {})
       .mapping('map')
-      .readyOnLoad();
-
-    analytics.validate(Integration, Test);
+      .readyOnLoad());
   });
 
   describe('#spy', function(){


### PR DESCRIPTION
- rename `validate` to `compare`
- remove notCalled, leave as didNotCall
- same with didNotReturn, removed notReturned

/cc @ianstormtaylor 
