### PR TITLE
add waitForScripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Reset the tester. This will call `reset` on the integration, as well as restore 
 Assert that the integration `load` method can load the library, and that `loaded` properly checks for the libraries existence, then `callback(err)`.
 
 ### <method>(args...)
- 
+
 Call one of the core analytics methods on the integration with `args...`. The methods include: `alias`, `identify`, `group`, `page`, and `track`.
 
 ### assert(actual)
@@ -135,3 +135,17 @@ Assert that a `fn` throws an error.
 ### doesNotThrow(fn)
 
 Assert than a `fn` does not throw an error.
+
+### waitForScripts(callback)
+
+Waits for all script elements to finish loading before calling `callback`. Often scripts loaded onto the page will add other scripts in order to support their functionality. These scripts can reference globals that we clear after each test, causing them to fail if they load too late.
+
+```js
+afterEach(function(done) {
+  analytics.waitForScripts(function() {
+    myIntegration.reset();
+    analytics.reset();
+    done();
+  });
+});
+```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,13 @@
 module.exports = function(config) {
   config.set({
     files: [
-      'test/**/*.test.js'
+      'test/**/*.test.js',
+      {
+        pattern: 'test/static/setGlobal.js',
+        included: false,
+        served: true,
+        nocache: true
+      }
     ],
 
     browsers: ['PhantomJS'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var keys = require('@ndhoule/keys');
 var spy = require('@segment/spy');
 var stub = require('@segment/stub');
 var type = require('component-type');
+var waitForScripts = require('./waitForScripts');
 
 /**
  * Integration testing plugin.
@@ -380,6 +381,14 @@ function plugin(analytics) {
    * @return {Tester}
    */
   analytics.assert = assert;
+
+  /**
+   * Wait for script elements to finish loading to avoid errors if they load
+   * after a reset.
+   *
+   * @param {Function} callback
+   */
+  analytics.waitForScripts = waitForScripts;
 
   /**
    * Expose all of the methods on `assert`.

--- a/lib/waitForScripts.js
+++ b/lib/waitForScripts.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var each = require('@ndhoule/each');
+var keys = require('@ndhoule/keys');
+
+var TIMEOUT = 1000;
+
+var createElement = document.createElement;
+document.createElement = function() {
+  var tag = createElement.apply(this, arguments);
+  if (tag.tagName === 'SCRIPT') {
+    watchScript(tag);
+  }
+  return tag;
+};
+
+var waiting = {};
+var nextId = 0;
+
+var watchCallbacks = [];
+
+function watchScript(script) {
+  var id = nextId++;
+  // Hold on to a reference to the script element until it loads. Chrome seems
+  // to not call the event listeners in some cases if an explicit reference is
+  // not held.
+  waiting[id] = script;
+  var done = false;
+  var cancelId = setTimeout(onLoad, TIMEOUT);
+
+  var loadCallback = function() {
+    clearTimeout(cancelId);
+    onLoad();
+  };
+
+  if (script.addEventListener) {
+    script.addEventListener('load', loadCallback);
+  } else {
+    script.attachEvent('onload', loadCallback);
+  }
+
+  function onLoad() {
+    if (!done) {
+      done = true;
+      delete waiting[id];
+      if (keys(waiting).length === 0) {
+        var callbacks = watchCallbacks;
+        watchCallbacks = [];
+        each(function(callback) {
+          callback();
+        }, callbacks);
+      }
+    }
+  }
+}
+
+module.exports = function(callback) {
+  if (keys(waiting).length === 0) {
+    return callback();
+  }
+  watchCallbacks.push(callback);
+};

--- a/test/static/setGlobal.js
+++ b/test/static/setGlobal.js
@@ -1,0 +1,3 @@
+'use strict';
+
+window.__setGlobal__ = 1;


### PR DESCRIPTION
This provides a function to fix issues seen in the tests for various integrations caused by a race between scripts that an integration loads and the test framework.

This was tested against the adroll and route integrations, which have been failing spuriously due to this race condition.

It overrides the `document.createElement` method in order to track all dynamically created `script` tags. A map (`waiting`) is kept of all elements who have not yet loaded, which are removed from this map once the `load` event fires. Once the last removal happens, it will callback everyone waiting for scripts to load.